### PR TITLE
fix: set JSON Content-Type header in service risk report 

### DIFF
--- a/api/reports/service_risk_report.go
+++ b/api/reports/service_risk_report.go
@@ -22,9 +22,10 @@ func (c *CallsHandler) GetServiceRiskReport(rw http.ResponseWriter, req *http.Re
 		customerrors.HandleError(rw, err)
 		return
 	}
+	rw.Header().Set("Content-Type", "application/json")
 	err = json.NewEncoder(rw).Encode(report)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 	}
-	rw.Header().Set("Content-Type", "application/json")
+
 }

--- a/api/reports/service_risk_report_test.go
+++ b/api/reports/service_risk_report_test.go
@@ -54,6 +54,10 @@ func TestGetServiceRiskReportSuccess(t *testing.T) {
 		t.Fatalf("Failed to decode response body: %v", err)
 	}
 
+	if contentType := rw.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Errorf("Expected Content-Type %s, got %s", "application/json", contentType)
+	}
+
 	// Check that the correct report was returned
 	if report.DependentCount != mockReport.DependentCount {
 		t.Errorf("Expected DependentCount %d, got %d", mockReport.DependentCount, report.DependentCount)


### PR DESCRIPTION
## Description
* fixes where header is written for content type in service risk report
* adds validation to tests

<!-- Provide a short description of what this PR is changing -->
### Code Rabbit Summary
<!-- This section allows Code Rabbit to generate a summary -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP response header ordering to ensure Content-Type is properly set before response body encoding.

* **Tests**
  * Added verification to confirm Content-Type header correctness in API responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Fixes
<!-- Add any issues that this PR closes here -->
Closes #134 

## Post Deployment Tasks?
