### PR TITLE
Adds Interaction Types to depends_on

### DIFF
--- a/HTTP_COLLECTION/Dependencies/Create dependency.bru
+++ b/HTTP_COLLECTION/Dependencies/Create dependency.bru
@@ -37,10 +37,13 @@ docs {
   ```json
   {
     "id": "12973952-0165-400b-9178-a0fdbd90f967",
-    "version": "1.5.0"
+    "version": "1.5.0",
+    "interaction_type": "data"
   }
   
   ```
+  
+  Valid interaction_types are data, security, performance, async, config
   
   ## Status Codes
   | Status Code | Description |

--- a/internal/Enums.go
+++ b/internal/Enums.go
@@ -44,6 +44,6 @@ var ArchitectureRole = StringEnum{
 	members: []string{"entrypoint", "application", "infrastructure", "data"},
 }
 
-var DependencyType = StringEnum{
+var InteractionType = StringEnum{
 	members: []string{"data", "security", "performance", "async", "config"},
 }

--- a/internal/Enums.go
+++ b/internal/Enums.go
@@ -43,3 +43,7 @@ var ImpactDomain = StringEnum{
 var ArchitectureRole = StringEnum{
 	members: []string{"entrypoint", "application", "infrastructure", "data"},
 }
+
+var DependencyType = StringEnum{
+	members: []string{"data", "security", "performance", "async", "config"},
+}

--- a/neo4jrepositories/dependencyrepository/create.go
+++ b/neo4jrepositories/dependencyrepository/create.go
@@ -3,6 +3,7 @@ package dependencyrepository
 import (
 	"context"
 	"fmt"
+	"service-atlas/internal"
 	"service-atlas/internal/customerrors"
 	"service-atlas/repositories"
 
@@ -38,32 +39,29 @@ func (d *Neo4jDependencyRepository) AddDependency(ctx context.Context, id string
 		}
 
 		// Create the dependency relationship
-		var query string
-		var params map[string]any
+		query := `
+			MATCH (s1:Service {id: $serviceId})
+			MATCH (s2:Service {id: $dependencyId})
+			MERGE (s1)-[r:DEPENDS_ON]->(s2)
+			SET r.interaction_type = $interactionType
+			WITH r, 
+				 CASE WHEN $version IS NOT NULL AND $version <> "" 
+					  THEN $version 
+					  ELSE r.version 
+				 END AS resolvedVersion
+			SET r.version = resolvedVersion
+			RETURN r
+		`
+		interactionType := "data"
+		if internal.DependencyType.IsMember(dependency.InteractionType) {
+			interactionType = dependency.InteractionType
+		}
 
-		if dependency.Version != "" {
-			query = `
-				MATCH (s1:Service {id: $serviceId})
-				MATCH (s2:Service {id: $dependencyId})
-				MERGE (s1)-[r:DEPENDS_ON {version: $version}]->(s2)
-				RETURN r
-			`
-			params = map[string]any{
-				"serviceId":    id,
-				"dependencyId": dependency.Id,
-				"version":      dependency.Version,
-			}
-		} else {
-			query = `
-				MATCH (s1:Service {id: $serviceId})
-				MATCH (s2:Service {id: $dependencyId})
-				MERGE (s1)-[r:DEPENDS_ON]->(s2)
-				RETURN r
-			`
-			params = map[string]any{
-				"serviceId":    id,
-				"dependencyId": dependency.Id,
-			}
+		params := map[string]any{
+			"serviceId":       id,
+			"dependencyId":    dependency.Id,
+			"version":         dependency.Version,
+			"interactionType": interactionType,
 		}
 
 		_, err = tx.Run(ctx, query, params)

--- a/neo4jrepositories/dependencyrepository/create.go
+++ b/neo4jrepositories/dependencyrepository/create.go
@@ -3,7 +3,6 @@ package dependencyrepository
 import (
 	"context"
 	"fmt"
-	"service-atlas/internal"
 	"service-atlas/internal/customerrors"
 	"service-atlas/repositories"
 
@@ -52,16 +51,12 @@ func (d *Neo4jDependencyRepository) AddDependency(ctx context.Context, id string
 			SET r.version = resolvedVersion
 			RETURN r
 		`
-		interactionType := "data"
-		if internal.InteractionType.IsMember(dependency.InteractionType) {
-			interactionType = dependency.InteractionType
-		}
 
 		params := map[string]any{
 			"serviceId":       id,
 			"dependencyId":    dependency.Id,
 			"version":         dependency.Version,
-			"interactionType": interactionType,
+			"interactionType": dependency.InteractionType,
 		}
 
 		_, err = tx.Run(ctx, query, params)

--- a/neo4jrepositories/dependencyrepository/create.go
+++ b/neo4jrepositories/dependencyrepository/create.go
@@ -53,7 +53,7 @@ func (d *Neo4jDependencyRepository) AddDependency(ctx context.Context, id string
 			RETURN r
 		`
 		interactionType := "data"
-		if internal.DependencyType.IsMember(dependency.InteractionType) {
+		if internal.InteractionType.IsMember(dependency.InteractionType) {
 			interactionType = dependency.InteractionType
 		}
 

--- a/neo4jrepositories/dependencyrepository/create_test.go
+++ b/neo4jrepositories/dependencyrepository/create_test.go
@@ -52,7 +52,7 @@ func TestNeo4jDependencyRepository_AddDependency_WithVersion(t *testing.T) {
 	}
 
 	// Act
-	dep := repositories.Dependency{Id: depID, Version: "1.2.3"}
+	dep := repositories.Dependency{Id: depID, Version: "1.2.3", InteractionType: "data"}
 	if err := repo.AddDependency(ctx, serviceID, dep); err != nil {
 		t.Fatalf("AddDependency returned error: %v", err)
 	}

--- a/neo4jrepositories/dependencyrepository/create_test.go
+++ b/neo4jrepositories/dependencyrepository/create_test.go
@@ -57,11 +57,11 @@ func TestNeo4jDependencyRepository_AddDependency_WithVersion(t *testing.T) {
 		t.Fatalf("AddDependency returned error: %v", err)
 	}
 
-	// Assert: relationship exists with version
+	// Assert: relationship exists with version and interaction_type
 	read := driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
 	defer func() { _ = read.Close(ctx) }()
 	res, err := read.Run(ctx,
-		"MATCH (:Service {id: $sid})-[r:DEPENDS_ON]->(:Service {id: $did}) RETURN r.version AS version",
+		"MATCH (:Service {id: $sid})-[r:DEPENDS_ON]->(:Service {id: $did}) RETURN r.version AS version, r.interaction_type AS it",
 		map[string]any{"sid": serviceID, "did": depID},
 	)
 	if err != nil {
@@ -77,6 +77,82 @@ func TestNeo4jDependencyRepository_AddDependency_WithVersion(t *testing.T) {
 	}
 	if ver != "1.2.3" {
 		t.Fatalf("expected version %q, got %#v", "1.2.3", ver)
+	}
+	it, ok := rec.Get("it")
+	if !ok {
+		t.Fatalf("missing interaction_type property")
+	}
+	if it != "data" {
+		t.Fatalf("expected interaction_type %q, got %#v", "data", it)
+	}
+}
+
+func TestNeo4jDependencyRepository_AddDependency_WithInteractionType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	ctx := context.Background()
+
+	// Start Neo4j test container
+	tc, err := neo4jrepositories.NewTestContainerHelper(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = tc.Container.Terminate(ctx) })
+
+	// Connect driver
+	driver, err := neo4j.NewDriverWithContext(tc.Endpoint, neo4j.BasicAuth("neo4j", "letmein!", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = driver.Close(ctx) }()
+
+	repo := New(driver)
+
+	// Arrange: create two services
+	serviceID := "11111111-1111-1111-1111-111111111111"
+	depID := "22222222-2222-2222-2222-222222222222"
+	write := driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer func() { _ = write.Close(ctx) }()
+	if _, err = write.Run(ctx,
+		"CREATE (s1:Service {id: $sid, name: $sname}) RETURN s1",
+		map[string]any{"sid": serviceID, "sname": "svc-a"},
+	); err != nil {
+		t.Fatalf("failed to create service1: %v", err)
+	}
+	if _, err = write.Run(ctx,
+		"CREATE (s2:Service {id: $did, name: $dname}) RETURN s2",
+		map[string]any{"did": depID, "dname": "svc-b"},
+	); err != nil {
+		t.Fatalf("failed to create service2: %v", err)
+	}
+
+	// Act
+	dep := repositories.Dependency{Id: depID, InteractionType: "async"}
+	if err := repo.AddDependency(ctx, serviceID, dep); err != nil {
+		t.Fatalf("AddDependency returned error: %v", err)
+	}
+
+	// Assert: relationship exists with interaction_type
+	read := driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
+	defer func() { _ = read.Close(ctx) }()
+	res, err := read.Run(ctx,
+		"MATCH (:Service {id: $sid})-[r:DEPENDS_ON]->(:Service {id: $did}) RETURN r.interaction_type AS it",
+		map[string]any{"sid": serviceID, "did": depID},
+	)
+	if err != nil {
+		t.Fatalf("failed to verify dependency: %v", err)
+	}
+	rec, err := res.Single(ctx)
+	if err != nil {
+		t.Fatalf("expected single record verifying dependency: %v", err)
+	}
+	it, ok := rec.Get("it")
+	if !ok {
+		t.Fatalf("missing interaction_type property")
+	}
+	if it != "async" {
+		t.Fatalf("expected interaction_type %q, got %#v", "async", it)
 	}
 }
 

--- a/neo4jrepositories/dependencyrepository/get.go
+++ b/neo4jrepositories/dependencyrepository/get.go
@@ -80,7 +80,10 @@ func makeGetTransaction(ctx context.Context, id string, query string) func(tx ne
 			id, _ := record.Get("id")
 			name, _ := record.Get("name")
 			version, _ := record.Get("version")
-			interactionType, _ := record.Get("interaction_type")
+			interactionType, ok := record.Get("interaction_type")
+			if !ok {
+				return nil, fmt.Errorf("interaction_type not found")
+			}
 			serviceType, _ := record.Get("type")
 			dependency := &repositories.Dependency{
 				Id: id.(string),

--- a/neo4jrepositories/dependencyrepository/get.go
+++ b/neo4jrepositories/dependencyrepository/get.go
@@ -13,7 +13,7 @@ func (d *Neo4jDependencyRepository) GetDependencies(ctx context.Context, id stri
 
 	query := `
 			MATCH (s1:Service {id: $serviceId})-[r:DEPENDS_ON]->(s2:Service)
-			RETURN s2.id as id, s2.name as name, r.version as version, s2.type as type
+			RETURN s2.id as id, s2.name as name, r.version as version, s2.type as type, r.interaction_type as interaction_type
 		`
 	result, err := d.manager.ExecuteRead(ctx, makeGetTransaction(ctx, id, query))
 	if err != nil {
@@ -26,7 +26,7 @@ func (d *Neo4jDependencyRepository) GetDependencies(ctx context.Context, id stri
 func (d *Neo4jDependencyRepository) GetDependents(ctx context.Context, id string) ([]*repositories.Dependency, error) {
 	query := `
 			MATCH (s1:Service)-[r:DEPENDS_ON]->(s2:Service {id: $serviceId})
-			RETURN s1.id as id, s1.name as name, s1.type as type, r.version as version
+			RETURN s1.id as id, s1.name as name, s1.type as type, r.version as version, r.interaction_type as interaction_type
 		`
 	result, err := d.manager.ExecuteRead(ctx, makeGetTransaction(ctx, id, query))
 	if err != nil {
@@ -80,6 +80,7 @@ func makeGetTransaction(ctx context.Context, id string, query string) func(tx ne
 			id, _ := record.Get("id")
 			name, _ := record.Get("name")
 			version, _ := record.Get("version")
+			interactionType, _ := record.Get("interaction_type")
 			serviceType, _ := record.Get("type")
 			dependency := &repositories.Dependency{
 				Id: id.(string),
@@ -91,6 +92,12 @@ func makeGetTransaction(ctx context.Context, id string, query string) func(tx ne
 			}
 			if version != nil {
 				dependency.Version = version.(string)
+			}
+			if interactionType != nil {
+				dependency.InteractionType = interactionType.(string)
+			}
+			if dependency.InteractionType == "" {
+				dependency.InteractionType = "data"
 			}
 
 			if serviceType != nil {

--- a/neo4jrepositories/dependencyrepository/get_test.go
+++ b/neo4jrepositories/dependencyrepository/get_test.go
@@ -47,7 +47,7 @@ func TestNeo4jDependencyRepository_GetDependencies_Success(t *testing.T) {
 	if _, err = write.Run(ctx, "CREATE (s:Service {id: $id, name: 'svc-3', type: 'queue'}) RETURN s", map[string]any{"id": s3}); err != nil {
 		t.Fatalf("create s3: %v", err)
 	}
-	if _, err = write.Run(ctx, "MATCH (a:Service {id: $a}),(b:Service {id: $b}) MERGE (a)-[:DEPENDS_ON {version: '2.0.0', interaction_type: 'event'}]->(b)", map[string]any{"a": s1, "b": s2}); err != nil {
+	if _, err = write.Run(ctx, "MATCH (a:Service {id: $a}),(b:Service {id: $b}) MERGE (a)-[:DEPENDS_ON {version: '2.0.0', interaction_type: 'security'}]->(b)", map[string]any{"a": s1, "b": s2}); err != nil {
 		t.Fatalf("rel s1->s2: %v", err)
 	}
 	if _, err = write.Run(ctx, "MATCH (a:Service {id: $a}),(b:Service {id: $b}) MERGE (a)-[:DEPENDS_ON]->(b)", map[string]any{"a": s1, "b": s3}); err != nil {
@@ -72,8 +72,8 @@ func TestNeo4jDependencyRepository_GetDependencies_Success(t *testing.T) {
 			if d.Version != "2.0.0" {
 				t.Fatalf("expected version 2.0.0 for %s, got %q", s2, d.Version)
 			}
-			if d.InteractionType != "event" {
-				t.Fatalf("expected interaction_type 'event' for %s, got %q", s2, d.InteractionType)
+			if d.InteractionType != "security" {
+				t.Fatalf("expected interaction_type 'security' for %s, got %q", s2, d.InteractionType)
 			}
 			if d.Name == "" || d.ServiceType == "" {
 				t.Fatalf("expected name and type for %s", s2)

--- a/neo4jrepositories/dependencyrepository/get_test.go
+++ b/neo4jrepositories/dependencyrepository/get_test.go
@@ -47,7 +47,7 @@ func TestNeo4jDependencyRepository_GetDependencies_Success(t *testing.T) {
 	if _, err = write.Run(ctx, "CREATE (s:Service {id: $id, name: 'svc-3', type: 'queue'}) RETURN s", map[string]any{"id": s3}); err != nil {
 		t.Fatalf("create s3: %v", err)
 	}
-	if _, err = write.Run(ctx, "MATCH (a:Service {id: $a}),(b:Service {id: $b}) MERGE (a)-[:DEPENDS_ON {version: '2.0.0'}]->(b)", map[string]any{"a": s1, "b": s2}); err != nil {
+	if _, err = write.Run(ctx, "MATCH (a:Service {id: $a}),(b:Service {id: $b}) MERGE (a)-[:DEPENDS_ON {version: '2.0.0', interaction_type: 'event'}]->(b)", map[string]any{"a": s1, "b": s2}); err != nil {
 		t.Fatalf("rel s1->s2: %v", err)
 	}
 	if _, err = write.Run(ctx, "MATCH (a:Service {id: $a}),(b:Service {id: $b}) MERGE (a)-[:DEPENDS_ON]->(b)", map[string]any{"a": s1, "b": s3}); err != nil {
@@ -72,6 +72,9 @@ func TestNeo4jDependencyRepository_GetDependencies_Success(t *testing.T) {
 			if d.Version != "2.0.0" {
 				t.Fatalf("expected version 2.0.0 for %s, got %q", s2, d.Version)
 			}
+			if d.InteractionType != "event" {
+				t.Fatalf("expected interaction_type 'event' for %s, got %q", s2, d.InteractionType)
+			}
 			if d.Name == "" || d.ServiceType == "" {
 				t.Fatalf("expected name and type for %s", s2)
 			}
@@ -80,6 +83,9 @@ func TestNeo4jDependencyRepository_GetDependencies_Success(t *testing.T) {
 			found["svc-3"] = true
 			if d.Version != "" {
 				t.Fatalf("expected empty version for %s, got %q", s3, d.Version)
+			}
+			if d.InteractionType != "data" {
+				t.Fatalf("expected interaction_type 'data' (default) for %s, got %q", s3, d.InteractionType)
 			}
 			if d.Name == "" || d.ServiceType == "" {
 				t.Fatalf("expected name and type for %s", s3)
@@ -159,7 +165,7 @@ func TestNeo4jDependencyRepository_GetDependents_Success(t *testing.T) {
 	if _, err = write.Run(ctx, "CREATE (s:Service {id: $id, name: 'svc-C', type: 'worker'}) RETURN s", map[string]any{"id": sC}); err != nil {
 		t.Fatalf("create sC: %v", err)
 	}
-	if _, err = write.Run(ctx, "MATCH (a:Service {id: $a}),(b:Service {id: $b}) MERGE (a)-[:DEPENDS_ON {version: '0.1.0'}]->(b)", map[string]any{"a": sA, "b": sB}); err != nil {
+	if _, err = write.Run(ctx, "MATCH (a:Service {id: $a}),(b:Service {id: $b}) MERGE (a)-[:DEPENDS_ON {version: '0.1.0', interaction_type: 'async'}]->(b)", map[string]any{"a": sA, "b": sB}); err != nil {
 		t.Fatalf("rel sA->sB: %v", err)
 	}
 	if _, err = write.Run(ctx, "MATCH (a:Service {id: $a}),(b:Service {id: $b}) MERGE (a)-[:DEPENDS_ON]->(b)", map[string]any{"a": sC, "b": sB}); err != nil {
@@ -183,6 +189,9 @@ func TestNeo4jDependencyRepository_GetDependents_Success(t *testing.T) {
 			if d.Version != "0.1.0" {
 				t.Fatalf("expected version for A->B to be 0.1.0, got %q", d.Version)
 			}
+			if d.InteractionType != "async" {
+				t.Fatalf("expected interaction_type 'async' for A->B, got %q", d.InteractionType)
+			}
 			if d.Name == "" || d.ServiceType == "" {
 				t.Fatalf("expected name and type for A")
 			}
@@ -191,6 +200,9 @@ func TestNeo4jDependencyRepository_GetDependents_Success(t *testing.T) {
 			seen["C"] = true
 			if d.Version != "" {
 				t.Fatalf("expected empty version for C->B, got %q", d.Version)
+			}
+			if d.InteractionType != "data" {
+				t.Fatalf("expected interaction_type 'data' (default) for C->B, got %q", d.InteractionType)
 			}
 			if d.Name == "" || d.ServiceType == "" {
 				t.Fatalf("expected name and type for C")

--- a/repositories/dependency.go
+++ b/repositories/dependency.go
@@ -3,11 +3,11 @@ package repositories
 import "errors"
 
 type Dependency struct {
-	Id             string `json:"id"`
-	Version        string `json:"version,omitempty"`
-	Name           string `json:"name,omitempty"`
-	ServiceType    string `json:"type,omitempty"`
-	DependencyType string `json:"dependency_type,omitempty"`
+	Id              string `json:"id"`
+	Version         string `json:"version,omitempty"`
+	Name            string `json:"name,omitempty"`
+	ServiceType     string `json:"type,omitempty"`
+	InteractionType string `json:"interaction_type,omitempty"`
 }
 
 func (d *Dependency) Validate() error {

--- a/repositories/dependency.go
+++ b/repositories/dependency.go
@@ -1,6 +1,9 @@
 package repositories
 
-import "errors"
+import (
+	"errors"
+	"service-atlas/internal"
+)
 
 type Dependency struct {
 	Id              string `json:"id"`
@@ -13,6 +16,12 @@ type Dependency struct {
 func (d *Dependency) Validate() error {
 	if d.Id == "" {
 		return errors.New("dependency id is required")
+	}
+	if d.InteractionType == "" {
+		d.InteractionType = "data"
+	}
+	if !internal.InteractionType.IsMember(d.InteractionType) {
+		return errors.New("invalid interaction type")
 	}
 	return nil
 }

--- a/repositories/dependency.go
+++ b/repositories/dependency.go
@@ -3,10 +3,11 @@ package repositories
 import "errors"
 
 type Dependency struct {
-	Id          string `json:"id"`
-	Version     string `json:"version,omitempty"`
-	Name        string `json:"name,omitempty"`
-	ServiceType string `json:"type,omitempty"`
+	Id             string `json:"id"`
+	Version        string `json:"version,omitempty"`
+	Name           string `json:"name,omitempty"`
+	ServiceType    string `json:"type,omitempty"`
+	DependencyType string `json:"dependency_type,omitempty"`
 }
 
 func (d *Dependency) Validate() error {

--- a/repositories/dependency_test.go
+++ b/repositories/dependency_test.go
@@ -4,7 +4,8 @@ import "testing"
 
 func TestDependency_ValidateSuccess(t *testing.T) {
 	dep := Dependency{
-		Id: "test",
+		Id:              "test",
+		InteractionType: "config",
 	}
 	err := dep.Validate()
 	if err != nil {
@@ -24,4 +25,15 @@ func TestDependency_ValidateFailNoId(t *testing.T) {
 		}
 	}
 
+}
+
+func TestDependency_ValidateFailInvalidInteractionType(t *testing.T) {
+	dep := Dependency{
+		Id:              "test",
+		InteractionType: "invalid",
+	}
+	err := dep.Validate()
+	if err == nil {
+		t.Error("Expected error")
+	}
 }


### PR DESCRIPTION
## Description
- Adds new InteractionType enum
- Adds InteractionType to DEPENDS_ON edge
- Refactors cypher for dependency creation to single type
- Adds validation of dependency and setup of default to `data` 
<!-- Provide a short description of what this PR is changing -->
### Code Rabbit Summary
<!-- This section allows Code Rabbit to generate a summary -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dependencies now include an interaction_type property to classify relationships. Valid values: data, security, performance, async, config. Defaults to data when omitted.

* **Validation**
  * Requests with unknown interaction_type are rejected; empty values default to data.

* **Behavior**
  * Stored and returned dependency records include interaction_type.

* **Tests**
  * Updated and new tests cover interaction_type handling.

* **Documentation**
  * API docs and request schema updated to include interaction_type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Fixes
<!-- Add any issues that this PR closes here -->
Closes #180 

## Post Deployment Tasks?
