### PR TITLE
Add interaction type filter to dependency GET call

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,67 @@ This application supports the recording and tracking of categorized technical de
 I think adding technical debt (or code rot) is a useful way to track and quantify issues with services. Things that are in your work tracking software (Jira, etc.)
 may or may not always be picked up in a reasonable timeframe and may not be easily associated with the service in question.
 
+## Dependency Interaction Types
+
+### Summary
+Enriching `DEPENDS_ON` with interaction type classification to surface logical data flows and engineering intent. Rather than introducing a separate relationship type to distinguish logical data flows from operational dependencies, interaction types enrich the existing dependency graph with a classification that describes *why* one service depends on another.
+
+### Classification Types
+
+| Type | Default | Description |
+|---|---|---|
+| `data` | Yes | A direct, synchronous exchange of meaningful domain data between two services. Represents logical data flow. |
+| `security` | No | A dependency on a service that handles authentication, authorisation, or request routing (e.g. Auth Service, Reverse Proxy). |
+| `performance` | No | A dependency on a service that exists to optimise speed or reduce load (e.g. Redis cache, Elasticsearch). |
+| `async` | No | A dependency where the interaction is fire-and-forget or event-driven (e.g. RabbitMQ, Kafka). |
+| `config` | No | A dependency on a service that provides configuration, feature flags, or secrets at runtime (e.g. Vault, Feature flag service). |
+
+### Scope
+- New `interaction_type` field on the `DEPENDS_ON` relationship
+- Validation of allowed interaction types
+- Default behavior for existing relationships: if unset, treat as `data`
+- API support for filtering dependencies by `interaction_type`
+
+## Service Tiers (Criticality Classification)
+
+### Summary
+Service Tiers introduce a `tier` attribute on `Service` to represent how critical a component is to the overall operation of the platform. This helps reason about impact, prioritize work, and understand dependency risk across the system.
+
+### Tier Model
+Use 4 tiers, where Tier 1 is the most critical.
+
+- Tier 1 — Mission Critical
+  - Core to the platform’s primary purpose
+  - Outage results in total or near-total platform failure
+  - High customer, revenue, or availability impact
+- Tier 2 — Business Critical
+  - Platform remains partially functional if down
+  - Significant degradation of key features or workflows
+  - High user impact, but not a full outage
+- Tier 3 — Supporting
+  - Enhances or supports core functionality
+  - Failures are noticeable but tolerable short-term
+  - Often asynchronous or auxiliary services
+- Tier 4 — Non-Critical / Auxiliary
+  - Minimal operational impact if unavailable
+  - Internal tools, dashboards, or experimental components
+
+### Scope
+- New `tier` field on the Service model
+- Validation of allowed tier values (1–4)
+- Default behavior for existing services: if unset, treat as Tier 3
+- API support for creating, updating, and querying services by `tier`
+
+
 ## Neo4j Data Structure
 Services are created under a `Service` object, while releases are created under a `Release` object.
-Services can have a `Depend_ON` relationship that may have a version as part of the relationship
-Services `Released` a `Release`
+Services can have a `DEPENDS_ON` relationship that may have a `version` and an `interaction_type` as part of the relationship.
+Services `RELEASED` a `Release`
 Services `OWNS` a `Debt`
 
 Services also include a `tier` property to indicate operational criticality, validated to be an integer from 1 (most critical) to 4 (least critical). If not set, it defaults to Tier 3 (Supporting) behavior.
+
+`DEPENDS_ON` relationships include an `interaction_type` property to classify the nature of the dependency (defaulting to `data`).
 
 Releases will always have a date; releases without a date are assigned `now()` as the date. Releases may have an associated url, a version, or both, but require at least the url or a version to be present.
 
@@ -168,48 +222,5 @@ Notes:
 
 ## API Endpoints
 
-For more information on endpoints, see the [Bruno Collection](./HTTP_COLLECTION)
-
-## ChangeLog
-### V1.4.0
-_Date: 2025-12-19_
-- Introduces Service Tiers (criticality classification) with `tier` field on Service (allowed values 1–4)
-- Validates tier values and returns `tier` in API responses
-- Supports creating, updating, and querying services by `tier`
-- Defaults existing/unspecified services to Tier 3 behavior
-
-### V1.2.0
-_Date: 2025-11-09_
-- Refactors to use Chi http routing library
-- Adds support for associating teams to services
-- Adds test container tests to neo4j repositories
-
-## Service Tiers (Criticality Classification)
-
-### Summary
-Service Tiers introduce a `tier` attribute on `Service` to represent how critical a component is to the overall operation of the platform. This helps reason about impact, prioritize work, and understand dependency risk across the system.
-
-### Tier Model
-Use 4 tiers, where Tier 1 is the most critical.
-
-- Tier 1 — Mission Critical
-  - Core to the platform’s primary purpose
-  - Outage results in total or near-total platform failure
-  - High customer, revenue, or availability impact
-- Tier 2 — Business Critical
-  - Platform remains partially functional if down
-  - Significant degradation of key features or workflows
-  - High user impact, but not a full outage
-- Tier 3 — Supporting
-  - Enhances or supports core functionality
-  - Failures are noticeable but tolerable short-term
-  - Often asynchronous or auxiliary services
-- Tier 4 — Non-Critical / Auxiliary
-  - Minimal operational impact if unavailable
-  - Internal tools, dashboards, or experimental components
-
-### Scope
-- New `tier` field on the Service model
-- Validation of allowed tier values (1–4)
-- Default behavior for existing services: if unset, treat as Tier 3
-- API support for creating, updating, and querying services by `tier`
+For more information on endpoints, see the [Bruno Collection](./HTTP_COLLECTION).
+Detailed discussions and RFCs can be found on GitHub, for example: [RFC: Dependency Interaction Types](https://github.com/service-atlas/backend/discussions/178).

--- a/api/dependencies/get.go
+++ b/api/dependencies/get.go
@@ -16,7 +16,23 @@ func (s *ServiceCallsHandler) GetDependencies(rw http.ResponseWriter, req *http.
 		http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
-	dep, err := s.Repository.GetDependencies(req.Context(), id)
+	interaction_type := req.URL.Query().Get("interaction_type")
+	if !internal.InteractionType.IsMember(interaction_type) && interaction_type != "" {
+		http.Error(rw, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	logger := internal.LoggerFromContext(req.Context())
+	logger.Debug("Getting dependencies",
+		slog.String("service_id", id),
+		slog.String("interaction_type", interaction_type),
+	)
+	var dep []*repositories.Dependency
+	var err error
+	if interaction_type != "" {
+		dep, err = s.Repository.GetDependenciesByInteractionType(req.Context(), id, interaction_type)
+	} else {
+		dep, err = s.Repository.GetDependencies(req.Context(), id)
+	}
 	if err != nil {
 		customerrors.HandleError(rw, err)
 		return

--- a/api/dependencies/get_test.go
+++ b/api/dependencies/get_test.go
@@ -84,6 +84,164 @@ func TestGetByIdSuccess(t *testing.T) {
 	}
 }
 
+func TestGetDependenciesByInteractionTypeSuccess(t *testing.T) {
+	// Create mock dependencies with different interaction types
+	mockDeps := []map[string]any{
+		{
+			"id":               "dependency-id-1",
+			"name":             "Dependency 1",
+			"version":          "1.0.0",
+			"interaction_type": "security",
+		},
+		{
+			"id":               "dependency-id-2",
+			"name":             "Dependency 2",
+			"version":          "2.0.0",
+			"interaction_type": "data",
+		},
+		{
+			"id":               "dependency-id-3",
+			"name":             "Dependency 3",
+			"version":          "1.1.0",
+			"interaction_type": "security",
+		},
+	}
+
+	// Create a handler with mocked dependencies
+	handler := ServiceCallsHandler{
+		Repository: mockDependencyRepository{
+			Data: func() []map[string]any {
+				return mockDeps
+			},
+			Err: nil, // No error
+		},
+	}
+
+	// Create a request with interaction_type filter
+	req, err := http.NewRequest("GET", "/services/be00abbc-42c6-47aa-a45a-e4e02cb6363f/dependencies?interaction_type=security", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.SetPathValue("id", "be00abbc-42c6-47aa-a45a-e4e02cb6363f")
+
+	// Create a response recorder
+	rw := httptest.NewRecorder()
+
+	// Call the handler
+	handler.GetDependencies(rw, req)
+
+	// Check the response
+	if rw.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, rw.Code)
+	}
+
+	// Check the content type
+	contentType := rw.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("Expected Content-Type %s, got %s", "application/json", contentType)
+	}
+
+	// Decode the response
+	var dependencies []*repositories.Dependency
+	err = json.NewDecoder(rw.Body).Decode(&dependencies)
+	if err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	// Check that only dependencies with interaction_type 'security' are returned
+	expectedCount := 2 // There are 2 dependencies with interaction_type 'security'
+	if len(dependencies) != expectedCount {
+		t.Errorf("Expected %d dependencies, got %d", expectedCount, len(dependencies))
+	}
+
+	// Check that all returned dependencies have the correct interaction_type
+	for _, dep := range dependencies {
+		if dep.InteractionType != "security" {
+			t.Errorf("Expected interaction_type %s, got %s", "security", dep.InteractionType)
+		}
+	}
+}
+
+func TestGetDependenciesByInteractionTypeInvalid(t *testing.T) {
+	// Create a handler
+	handler := ServiceCallsHandler{
+		Repository: mockDependencyRepository{
+			Data: func() []map[string]any {
+				return []map[string]any{}
+			},
+			Err: nil,
+		},
+	}
+
+	// Create a request with an invalid interaction_type
+	req, err := http.NewRequest("GET", "/services/be00abbc-42c6-47aa-a45a-e4e02cb6363f/dependencies?interaction_type=invalid_type", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.SetPathValue("id", "be00abbc-42c6-47aa-a45a-e4e02cb6363f")
+
+	// Create a response recorder
+	rw := httptest.NewRecorder()
+
+	// Call the handler
+	handler.GetDependencies(rw, req)
+
+	// Check the response
+	if rw.Code != http.StatusBadRequest {
+		t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, rw.Code)
+	}
+}
+
+func TestGetDependenciesWithEmptyInteractionType(t *testing.T) {
+	// Create mock dependencies
+	mockDeps := []map[string]any{
+		{
+			"id":               "dependency-id-1",
+			"name":             "Dependency 1",
+			"interaction_type": "security",
+		},
+	}
+
+	// Create a handler
+	handler := ServiceCallsHandler{
+		Repository: mockDependencyRepository{
+			Data: func() []map[string]any {
+				return mockDeps
+			},
+			Err: nil,
+		},
+	}
+
+	// Create a request with an empty interaction_type
+	req, err := http.NewRequest("GET", "/services/be00abbc-42c6-47aa-a45a-e4e02cb6363f/dependencies?interaction_type=", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.SetPathValue("id", "be00abbc-42c6-47aa-a45a-e4e02cb6363f")
+
+	// Create a response recorder
+	rw := httptest.NewRecorder()
+
+	// Call the handler
+	handler.GetDependencies(rw, req)
+
+	// Check the response
+	if rw.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, rw.Code)
+	}
+
+	// Decode the response
+	var dependencies []*repositories.Dependency
+	err = json.NewDecoder(rw.Body).Decode(&dependencies)
+	if err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if len(dependencies) != 1 {
+		t.Errorf("Expected 1 dependency, got %d", len(dependencies))
+	}
+}
+
 func TestGetByIdInvalidPath(t *testing.T) {
 	// Create a handler with mocked dependencies
 	handler := ServiceCallsHandler{

--- a/api/dependencies/get_test.go
+++ b/api/dependencies/get_test.go
@@ -242,6 +242,119 @@ func TestGetDependenciesWithEmptyInteractionType(t *testing.T) {
 	}
 }
 
+func TestGetDependenciesNoDataReturnsEmptyArray(t *testing.T) {
+	// Create a handler with no dependencies
+	handler := ServiceCallsHandler{
+		Repository: mockDependencyRepository{
+			Data: func() []map[string]any {
+				return []map[string]any{}
+			},
+			Err: nil, // No error
+		},
+	}
+
+	// Create a request
+	req, err := http.NewRequest("GET", "/services/be00abbc-42c6-47aa-a45a-e4e02cb6363f/dependencies", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.SetPathValue("id", "be00abbc-42c6-47aa-a45a-e4e02cb6363f")
+	// Create a response recorder
+	rw := httptest.NewRecorder()
+
+	// Call the handler
+	handler.GetDependencies(rw, req)
+
+	// Check the response
+	if rw.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, rw.Code)
+	}
+
+	// Check the body for an empty array, not null
+	body := rw.Body.String()
+	if body != "[]\n" {
+		t.Errorf("Expected empty array [], got %q", body)
+	}
+}
+
+func TestGetDependenciesByInteractionTypeNoDataReturnsEmptyArray(t *testing.T) {
+	// Create a handler with dependencies of other types, but not 'security'
+	mockDeps := []map[string]any{
+		{
+			"id":               "dependency-id-1",
+			"name":             "Dependency 1",
+			"interaction_type": "data",
+		},
+	}
+
+	handler := ServiceCallsHandler{
+		Repository: mockDependencyRepository{
+			Data: func() []map[string]any {
+				return mockDeps
+			},
+			Err: nil, // No error
+		},
+	}
+
+	// Create a request with interaction_type=security (which won't have results)
+	req, err := http.NewRequest("GET", "/services/be00abbc-42c6-47aa-a45a-e4e02cb6363f/dependencies?interaction_type=security", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.SetPathValue("id", "be00abbc-42c6-47aa-a45a-e4e02cb6363f")
+	// Create a response recorder
+	rw := httptest.NewRecorder()
+
+	// Call the handler
+	handler.GetDependencies(rw, req)
+
+	// Check the response
+	if rw.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, rw.Code)
+	}
+
+	// Check the body for an empty array, not null
+	body := rw.Body.String()
+	if body != "[]\n" {
+		t.Errorf("Expected empty array [], got %q", body)
+	}
+}
+
+func TestGetDependentsNoDataReturnsEmptyArray(t *testing.T) {
+	// Create a handler with no dependents
+	handler := ServiceCallsHandler{
+		Repository: mockDependencyRepository{
+			Data: func() []map[string]any {
+				return []map[string]any{}
+			},
+			Err: nil, // No error
+		},
+	}
+
+	// Create a request
+	req, err := http.NewRequest("GET", "/services/be00abbc-42c6-47aa-a45a-e4e02cb6363f/dependents", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.SetPathValue("id", "be00abbc-42c6-47aa-a45a-e4e02cb6363f")
+	// Create a response recorder
+	rw := httptest.NewRecorder()
+
+	// Call the handler
+	handler.GetDependents(rw, req)
+
+	// Check the response
+	if rw.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, rw.Code)
+	}
+
+	// Check the body for an empty array, not null
+	body := rw.Body.String()
+	if body != "[]\n" {
+		t.Errorf("Expected empty array [], got %q", body)
+	}
+}
+
 func TestGetByIdInvalidPath(t *testing.T) {
 	// Create a handler with mocked dependencies
 	handler := ServiceCallsHandler{

--- a/api/dependencies/mock_repository.go
+++ b/api/dependencies/mock_repository.go
@@ -52,6 +52,50 @@ func (repo mockDependencyRepository) GetDependencies(_ context.Context, _ string
 	return dependencies, nil
 }
 
+func (repo mockDependencyRepository) GetDependenciesByInteractionType(_ context.Context, _, interaction_type string) ([]*repositories.Dependency, error) {
+	if repo.Err != nil {
+		return nil, repo.Err
+	}
+
+	// Convert the mock data to the expected return type
+	data := repo.Data()
+	dependencies := make([]*repositories.Dependency, 0, len(data))
+
+	for _, item := range data {
+		// Filter by interaction type if provided
+		if interaction_type != "" {
+			if itemInteractionType, ok := item["interaction_type"].(string); ok {
+				if itemInteractionType != interaction_type {
+					continue
+				}
+			} else {
+				// If item doesn't have interaction_type, and we are filtering, skip it
+				// unless we assume a default. But for mock, let's be explicit.
+				continue
+			}
+		}
+
+		dep := &repositories.Dependency{}
+
+		if id, ok := item["id"].(string); ok {
+			dep.Id = id
+		}
+		if name, ok := item["name"].(string); ok {
+			dep.Name = name
+		}
+		if version, ok := item["version"].(string); ok {
+			dep.Version = version
+		}
+		if it, ok := item["interaction_type"].(string); ok {
+			dep.InteractionType = it
+		}
+
+		dependencies = append(dependencies, dep)
+	}
+
+	return dependencies, nil
+}
+
 func (repo mockDependencyRepository) GetDependents(_ context.Context, _ string) ([]*repositories.Dependency, error) {
 	if repo.Err != nil {
 		return nil, repo.Err

--- a/neo4jrepositories/dependencyrepository/get.go
+++ b/neo4jrepositories/dependencyrepository/get.go
@@ -116,10 +116,7 @@ func makeGetTransaction(ctx context.Context, query string, parameters map[string
 			id, _ := record.Get("id")
 			name, _ := record.Get("name")
 			version, _ := record.Get("version")
-			interactionType, ok := record.Get("interaction_type")
-			if !ok {
-				return nil, fmt.Errorf("interaction_type not found")
-			}
+			interactionType, _ := record.Get("interaction_type")
 			serviceType, _ := record.Get("type")
 			dependency := &repositories.Dependency{
 				Id: id.(string),

--- a/neo4jrepositories/dependencyrepository/get.go
+++ b/neo4jrepositories/dependencyrepository/get.go
@@ -15,7 +15,27 @@ func (d *Neo4jDependencyRepository) GetDependencies(ctx context.Context, id stri
 			MATCH (s1:Service {id: $serviceId})-[r:DEPENDS_ON]->(s2:Service)
 			RETURN s2.id as id, s2.name as name, r.version as version, s2.type as type, r.interaction_type as interaction_type
 		`
-	result, err := d.manager.ExecuteRead(ctx, makeGetTransaction(ctx, id, query))
+	parameters := map[string]any{
+		"serviceId": id,
+	}
+	result, err := d.manager.ExecuteRead(ctx, makeGetTransaction(ctx, query, parameters))
+	if err != nil {
+		return nil, err
+	}
+
+	return result.([]*repositories.Dependency), nil
+}
+func (d *Neo4jDependencyRepository) GetDependenciesByInteractionType(ctx context.Context, id, interaction_type string) ([]*repositories.Dependency, error) {
+
+	query := `
+			MATCH (s1:Service {id: $serviceId})-[r:DEPENDS_ON {interaction_type: $interaction_type}]->(s2:Service)
+			RETURN s2.id as id, s2.name as name, r.version as version, s2.type as type, r.interaction_type as interaction_type
+		`
+	parameters := map[string]any{
+		"serviceId":        id,
+		"interaction_type": interaction_type,
+	}
+	result, err := d.manager.ExecuteRead(ctx, makeGetTransaction(ctx, query, parameters))
 	if err != nil {
 		return nil, err
 	}
@@ -28,23 +48,24 @@ func (d *Neo4jDependencyRepository) GetDependents(ctx context.Context, id string
 			MATCH (s1:Service)-[r:DEPENDS_ON]->(s2:Service {id: $serviceId})
 			RETURN s1.id as id, s1.name as name, s1.type as type, r.version as version, r.interaction_type as interaction_type
 		`
-	result, err := d.manager.ExecuteRead(ctx, makeGetTransaction(ctx, id, query))
+	parameters := map[string]any{
+		"serviceId": id,
+	}
+	result, err := d.manager.ExecuteRead(ctx, makeGetTransaction(ctx, query, parameters))
 	if err != nil {
 		return nil, err
 	}
 	return result.([]*repositories.Dependency), nil
 }
 
-func makeGetTransaction(ctx context.Context, id string, query string) func(tx neo4j.ManagedTransaction) (any, error) {
+func makeGetTransaction(ctx context.Context, query string, parameters map[string]any) func(tx neo4j.ManagedTransaction) (any, error) {
 	return func(tx neo4j.ManagedTransaction) (any, error) {
 		// First check if the service exists
 		checkQuery := `
 			MATCH (s:Service {id: $serviceId})
 			RETURN s
 		`
-		result, err := tx.Run(ctx, checkQuery, map[string]any{
-			"serviceId": id,
-		})
+		result, err := tx.Run(ctx, checkQuery, parameters)
 		if err != nil {
 			return nil, err
 		}
@@ -55,17 +76,24 @@ func makeGetTransaction(ctx context.Context, id string, query string) func(tx ne
 			return nil, err
 		}
 		if len(records) == 0 {
+			serviceId, ok := parameters["serviceId"]
+			if !ok {
+				serviceId = "unknown"
+			}
+			if id, ok := serviceId.(string); ok {
+				serviceId = id
+			} else {
+				serviceId = "unknown"
+			}
 			return nil, &customerrors.HTTPError{
 				Status: 404,
-				Msg:    fmt.Sprintf("Service not found: %s", id),
+				Msg:    fmt.Sprintf("Service not found: %s", serviceId),
 			}
 		}
 
 		// Find all services that depend on the service with the given ID
 
-		result, err = tx.Run(ctx, query, map[string]any{
-			"serviceId": id,
-		})
+		result, err = tx.Run(ctx, query, parameters)
 		if err != nil {
 			return nil, err
 		}

--- a/neo4jrepositories/dependencyrepository/get.go
+++ b/neo4jrepositories/dependencyrepository/get.go
@@ -23,7 +23,11 @@ func (d *Neo4jDependencyRepository) GetDependencies(ctx context.Context, id stri
 		return nil, err
 	}
 
-	return result.([]*repositories.Dependency), nil
+	deps := result.([]*repositories.Dependency)
+	if deps == nil {
+		return []*repositories.Dependency{}, nil
+	}
+	return deps, nil
 }
 func (d *Neo4jDependencyRepository) GetDependenciesByInteractionType(ctx context.Context, id, interaction_type string) ([]*repositories.Dependency, error) {
 
@@ -40,7 +44,11 @@ func (d *Neo4jDependencyRepository) GetDependenciesByInteractionType(ctx context
 		return nil, err
 	}
 
-	return result.([]*repositories.Dependency), nil
+	deps := result.([]*repositories.Dependency)
+	if deps == nil {
+		return []*repositories.Dependency{}, nil
+	}
+	return deps, nil
 }
 
 func (d *Neo4jDependencyRepository) GetDependents(ctx context.Context, id string) ([]*repositories.Dependency, error) {
@@ -98,7 +106,7 @@ func makeGetTransaction(ctx context.Context, query string, parameters map[string
 			return nil, err
 		}
 
-		var dependencies []*repositories.Dependency
+		var dependencies = []*repositories.Dependency{}
 		records, err = result.Collect(ctx)
 		if err != nil {
 			return nil, err

--- a/neo4jrepositories/dependencyrepository/get_test.go
+++ b/neo4jrepositories/dependencyrepository/get_test.go
@@ -97,6 +97,118 @@ func TestNeo4jDependencyRepository_GetDependencies_Success(t *testing.T) {
 	}
 }
 
+func TestNeo4jDependencyRepository_GetDependenciesByInteractionType_Success(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	ctx := context.Background()
+
+	// Start Neo4j test container
+	tc, err := neo4jrepositories.NewTestContainerHelper(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = tc.Container.Terminate(ctx) })
+
+	// Connect driver
+	driver, err := neo4j.NewDriverWithContext(tc.Endpoint, neo4j.BasicAuth("neo4j", "letmein!", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = driver.Close(ctx) }()
+
+	repo := New(driver)
+
+	// Arrange: s1 depends on s2 (interaction_type: security) and s3 (interaction_type: data)
+	s1 := "55555555-5555-5555-5555-555555555555"
+	s2 := "66666666-6666-6666-6666-666666666666"
+	s3 := "77777777-7777-7777-7777-777777777777"
+	write := driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer func() { _ = write.Close(ctx) }()
+	if _, err = write.Run(ctx, "CREATE (s:Service {id: $id, name: 'svc-1', type: 'api'}) RETURN s", map[string]any{"id": s1}); err != nil {
+		t.Fatalf("create s1: %v", err)
+	}
+	if _, err = write.Run(ctx, "CREATE (s:Service {id: $id, name: 'svc-2', type: 'db'}) RETURN s", map[string]any{"id": s2}); err != nil {
+		t.Fatalf("create s2: %v", err)
+	}
+	if _, err = write.Run(ctx, "CREATE (s:Service {id: $id, name: 'svc-3', type: 'queue'}) RETURN s", map[string]any{"id": s3}); err != nil {
+		t.Fatalf("create s3: %v", err)
+	}
+	if _, err = write.Run(ctx, "MATCH (a:Service {id: $a}),(b:Service {id: $b}) MERGE (a)-[:DEPENDS_ON {version: '2.0.0', interaction_type: 'security'}]->(b)", map[string]any{"a": s1, "b": s2}); err != nil {
+		t.Fatalf("rel s1->s2: %v", err)
+	}
+	if _, err = write.Run(ctx, "MATCH (a:Service {id: $a}),(b:Service {id: $b}) MERGE (a)-[:DEPENDS_ON {interaction_type: 'data'}]->(b)", map[string]any{"a": s1, "b": s3}); err != nil {
+		t.Fatalf("rel s1->s3: %v", err)
+	}
+
+	// Act: Get only 'security' dependencies
+	deps, err := repo.GetDependenciesByInteractionType(ctx, s1, "security")
+	if err != nil {
+		t.Fatalf("GetDependenciesByInteractionType returned error: %v", err)
+	}
+
+	// Assert
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dependency, got %d", len(deps))
+	}
+	if deps[0].Id != s2 {
+		t.Fatalf("expected dependency ID %s, got %s", s2, deps[0].Id)
+	}
+	if deps[0].InteractionType != "security" {
+		t.Fatalf("expected interaction_type 'security', got %q", deps[0].InteractionType)
+	}
+
+	// Act: Get only 'data' dependencies
+	deps, err = repo.GetDependenciesByInteractionType(ctx, s1, "data")
+	if err != nil {
+		t.Fatalf("GetDependenciesByInteractionType returned error: %v", err)
+	}
+
+	// Assert
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dependency, got %d", len(deps))
+	}
+	if deps[0].Id != s3 {
+		t.Fatalf("expected dependency ID %s, got %s", s3, deps[0].Id)
+	}
+	if deps[0].InteractionType != "data" {
+		t.Fatalf("expected interaction_type 'data', got %q", deps[0].InteractionType)
+	}
+}
+
+func TestNeo4jDependencyRepository_GetDependenciesByInteractionType_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	ctx := context.Background()
+
+	tc, err := neo4jrepositories.NewTestContainerHelper(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = tc.Container.Terminate(ctx) })
+
+	driver, err := neo4j.NewDriverWithContext(tc.Endpoint, neo4j.BasicAuth("neo4j", "letmein!", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = driver.Close(ctx) }()
+
+	repo := New(driver)
+
+	_, err = repo.GetDependenciesByInteractionType(ctx, "00000000-0000-0000-0000-000000000000", "security")
+	if err == nil {
+		t.Fatalf("expected error when service not found")
+	}
+	if pathErr, ok := errors.AsType[*customerrors.HTTPError](err); ok {
+		if pathErr.Status != 404 {
+			t.Fatalf("expected HTTP 404, got %d", pathErr.Status)
+		}
+	} else {
+		t.Fatalf("expected *customerrors.HTTPError, got %T: %v", err, err)
+	}
+}
+
 func TestNeo4jDependencyRepository_GetDependencies_NotFound(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/repositories/interfaces.go
+++ b/repositories/interfaces.go
@@ -39,6 +39,8 @@ type DependencyRepository interface {
 	AddDependency(ctx context.Context, id string, dependency Dependency) error
 	// GetDependencies retrieves all dependencies of a resource.
 	GetDependencies(ctx context.Context, id string) ([]*Dependency, error)
+	// GetDependenciesByInteractionType retrieves all dependencies of a resource of a specific interaction type.
+	GetDependenciesByInteractionType(ctx context.Context, id, interaction_type string) ([]*Dependency, error)
 	// GetDependents retrieves all resources that depend on a given resource.
 	GetDependents(ctx context.Context, id string) ([]*Dependency, error)
 	// DeleteDependency deletes a dependency between two resources.


### PR DESCRIPTION
## Description
- adds new `interaction_type` query parameter to get dependencies
- updates readme that was missed in previous PR
<!-- Provide a short description of what this PR is changing -->
### Code Rabbit Summary
<!-- This section allows Code Rabbit to generate a summary -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API supports dependency filtering by interaction type (data, security, performance, async, config).
  * Services include a tier/criticality attribute (Tier 1–4) with create/update/query support.

* **Behavior Changes / Bug Fixes**
  * Invalid interaction_type values return 400 Bad Request.
  * interaction_type defaults to "data" when unset; service tier defaults to Tier 3.
  * Endpoints consistently return empty JSON arrays instead of null.

* **Documentation**
  * README updated for interaction types and service tiers; RFC link added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Fixes
<!-- Add any issues that this PR closes here -->
Closes #182 

## Post Deployment Tasks?
